### PR TITLE
Fix capture in 180 rotation

### DIFF
--- a/raspi2png.c
+++ b/raspi2png.c
@@ -337,7 +337,7 @@ main(
 
             if (displayRotated & 0x20000) // flip vertical
             {
-                dmxYoffset = (dmxHeight - j) * dmxPitch;
+                dmxYoffset = (dmxHeight - j - 1) * dmxPitch;
             }
             else
             {
@@ -355,7 +355,7 @@ main(
             }
             else
             {
-                dmxXoffset = (dmxWidth - j) * dmxBytesPerPixel;
+                dmxXoffset = (dmxWidth - j - 1) * dmxBytesPerPixel;
             }
 
             break;
@@ -368,7 +368,7 @@ main(
             }
             else
             {
-                dmxYoffset = (dmxHeight - j) * dmxPitch;
+                dmxYoffset = (dmxHeight - j - 1) * dmxPitch;
             }
 
             break;
@@ -377,7 +377,7 @@ main(
 
             if (displayRotated & 0x20000) // flip vertical
             {
-                dmxXoffset = (dmxWidth - j) * dmxBytesPerPixel;
+                dmxXoffset = (dmxWidth - j - 1) * dmxBytesPerPixel;
             }
             else
             {
@@ -400,7 +400,7 @@ main(
 
                 if (displayRotated & 0x10000) // flip horizontal
                 {
-                    dmxXoffset = (dmxWidth - i) * dmxBytesPerPixel;
+                    dmxXoffset = (dmxWidth - i - 1) * dmxBytesPerPixel;
                 }
                 else
                 {
@@ -413,7 +413,7 @@ main(
 
                 if (displayRotated & 0x10000) // flip horizontal
                 {
-                    dmxYoffset = (dmxHeight - i) * dmxPitch;
+                    dmxYoffset = (dmxHeight - i - 1) * dmxPitch;
                 }
                 else
                 {
@@ -430,7 +430,7 @@ main(
                 }
                 else
                 {
-                    dmxXoffset = (dmxWidth - i) * dmxBytesPerPixel;
+                    dmxXoffset = (dmxWidth - i - 1) * dmxBytesPerPixel;
                 }
 
                 break;
@@ -443,7 +443,7 @@ main(
                 }
                 else
                 {
-                    dmxYoffset = (dmxHeight - i) * dmxPitch;
+                    dmxYoffset = (dmxHeight - i - 1) * dmxPitch;
                 }
 
                 break;


### PR DESCRIPTION
I've got a bit of an issue with raspi2png on my HDMIPi. I use display_rotate=2 (mostly in order to keep the cables out of the way!) but raspi2png crashes out with a segfault in this configuration (works just fine when the display isn't rotated). I've had a quick look at the source and it seems there's a bunch of off-by-1 errors when dealing with flipped/rotated displays.

For example in my case the display is 1280x800 and it rotated 180 degrees. So in this case both the Y and X directions need reading "backwards". That means the first offset calculated for the PNG buffer (without this patch) will be 800pitch + 1280bpp = 3075840. But the PNG buffer is 3072000 so the first write falls off the end of the buffer. Instead it wants to be 799pitch + 1279bpp = 3071997 (which as expected is 3 bytes from end).

I think I've corrected all the off-by-1 errors in this patch, but I've only tested it with my display unrotated and rotated 180. Might be worth testing with the 90 and 270 cases as well!